### PR TITLE
docs(readme): add AUR instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ If you're a Rust programmer, poketex can be installed with cargo.
 cargo install poketex
 ```
 
+### Install from the AUR
+
+If you're using Arch Linux, you can install poketex with using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
+
+```shell
+paru -S poketex
+```
+
 ## Building
 
 poketex is written in Rust, so you'll need to grab a [Rust installation](https://www.rust-lang.org/) in order to compile it.


### PR DESCRIPTION
Hello! 🐻

I created the following AUR packages for installing poketex on Arch Linux:

- https://aur.archlinux.org/packages/poketex
- https://aur.archlinux.org/packages/poketex-git

This PR simply updates README.md for mentioning the installation instructions.

Cheers!
