### PR TITLE
feat: add PageUp/PageDown key bindings for faster scroll

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,9 +134,11 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: AppState) -> io::Res
 
                     KeyCode::Down => app.pm.next(),
                     KeyCode::Char('j') => app.pm.next(),
+                    KeyCode::PageDown => app.pm.scroll_down(4),
 
                     KeyCode::Up => app.pm.previous(),
                     KeyCode::Char('k') => app.pm.previous(),
+                    KeyCode::PageUp => app.pm.scroll_up(4),
 
                     KeyCode::Left => app.pm.dex.previous(),
                     KeyCode::Char('h') => app.pm.dex.previous(),

--- a/src/widget/pmlist.rs
+++ b/src/widget/pmlist.rs
@@ -103,6 +103,33 @@ impl PokemonListStatus {
         self.current(i);
     }
 
+    pub fn scroll_down(&mut self, amount: u8) {
+        if let Some(i) = self
+            .state
+            .selected()
+            .and_then(|v| v.checked_add(amount.into()))
+            .map(|mut index| {
+                if index > self.items.len() {
+                    index = self.items.len() - 1;
+                }
+                index
+            })
+        {
+            self.current(i);
+        }
+    }
+
+    pub fn scroll_up(&mut self, amount: u8) {
+        if let Some(i) = self
+            .state
+            .selected()
+            .and_then(|v| v.checked_sub(amount.into()))
+            .or(Some(0))
+        {
+            self.current(i);
+        }
+    }
+
     pub fn set_list_filter(&mut self, filter: String) {
         if filter.eq("") {
             self.items = self.items_clone.clone();


### PR DESCRIPTION
Scrolling with the arrow keys was a bit slow so this PR defines PageUp/PageDown keys for scrolling 4 items at a time.

![rec_20230224T011906](https://user-images.githubusercontent.com/24392180/221043862-9d20a897-a620-4e6c-80f7-3e0218c76f9c.gif)
