### PR TITLE
chore: update Cargo.lock for 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "poketex"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "clap",
  "crossterm",


### PR DESCRIPTION
The version was bumped in 523a2bd0da9882aec352f2788ab462d8ae819aae but Cargo.lock wasn't updated.
