### PR TITLE
chore(ci): build with `--locked` flag

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: ${{ matrix.build || 'stable' }}
 
       - name: Build debug
-        run: cargo build
+        run: cargo build --locked
 
       - name: Test
         run: cargo test --all-features


### PR DESCRIPTION
This PR updates continuous integration workflow for building/testing with '--locked' flag which means Cargo.lock should be up-to-date thus issues like #6 can be spotted early in the development phase.
