### PR TITLE
Added windows paths support for colorscripts detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,16 @@ fn get_assets_dir_path() -> Result<PathBuf> {
         }
     };
 
+    // Windows equivalent
+    #[cfg(windows)]
+    if let Ok(data_dir) = std::env::var("LOCALAPPDATA") {
+        let data_home = Path::new(&data_dir).join("poketex");
+        let assets_dir = data_home.join(assets_path);
+        if assets_dir.exists() {
+            return Ok(assets_dir);
+        }
+    }
+
     let usr_dir = Path::new("/usr/share/poketex");
     let assets_dir = usr_dir.join(assets_path);
     if assets_dir.exists() {


### PR DESCRIPTION
In previous versions, Poketex would only detect the colorscripts if they were in a XDG directory or if they were next to the executable.
This PR allows Poketex to detect colorscripts when they are in `C:\Users\USERNAME\AppData\Local`.