### PR TITLE
feat: implement fuzzy search and improve list navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +880,7 @@ dependencies = [
  "ansi-to-tui",
  "anyhow",
  "clap",
+ "fuzzy-matcher",
  "lazy_static",
  "ratatui",
  "regex",
@@ -1390,6 +1400,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ textwrap = "0.16.0"
 ansi-to-tui = "8.0.0"
 anyhow = "1.0.79"
 xdg = "2.5.2"
+fuzzy-matcher = "0.3.7"
 
 [profile.release]
 opt-level = "z"

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -21,9 +21,12 @@ impl KeyHandleResult {
 fn on_editing(app: &mut AppState, event: KeyEvent) -> KeyHandleResult {
     use KeyCode::*;
 
-    match event.code {
-        Esc => app.reset(),
-        Enter => app.tui.input_mode = InputMode::Normal,
+    match (event.code, event.modifiers) {
+        (Esc, _) => app.reset(),
+        (Enter, _) => app.tui.input_mode = InputMode::Normal,
+        (Up, _) => app.pokemon_list.previous(),
+        (Down, _) => app.pokemon_list.next(),
+        (Char('c'), KeyModifiers::CONTROL) => return KeyHandleResult::Exit,
         _ => {
             app.key_handle.input.handle_event(&Event::Key(event));
             app.pokemon_list.filter_query.clear();
@@ -61,9 +64,11 @@ fn on_normal(app: &mut AppState, event: KeyEvent) -> KeyHandleResult {
         },
 
         // handle other key
-        (c, _) => match c {
+        (code, modifiers) => match code {
+            Char('c') if modifiers == KeyModifiers::CONTROL => return KeyHandleResult::Exit,
             Char('q') => return KeyHandleResult::Exit,
             Char('H') => app.tui.toggle_help(),
+
             Char('E') => app.tui.toggle_show_list(),
             Char('A') => app.tui.toggle_show_abilities(),
             Char('V') => app.tui.toggle_show_iv(),

--- a/src/state/pokemon.rs
+++ b/src/state/pokemon.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, rc::Rc};
 
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use ratatui::widgets::{ListState, ScrollbarState};
 
 use crate::pokemon::{ascii_form::AsciiForms, AbilityMap, PokemonBundle, PokemonEntity};
@@ -57,11 +58,15 @@ impl PokemonListState {
     }
 
     pub fn len(&self) -> usize {
-        self.bundle.pokemon.len()
+        if self.filter_query.is_empty() {
+            self.bundle.pokemon.len()
+        } else {
+            self.filtered_list.len()
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.bundle.pokemon.is_empty()
+        self.len() == 0
     }
 
     pub fn ability_map(&self) -> Rc<AbilityMap> {
@@ -141,18 +146,23 @@ impl PokemonListState {
         self.filter_query.clone_from(&filter);
 
         if !filter.is_empty() {
+            let matcher = SkimMatcherV2::default();
             self.filtered_list.clear();
-            self.filtered_list.extend(
-                self.bundle
-                    .pokemon
-                    .iter()
-                    .filter(|item| {
-                        item.name_with_no()
-                            .to_lowercase()
-                            .contains(&filter.to_lowercase())
-                    })
-                    .cloned(),
-            );
+
+            // Filter by fuzzy match and sort by score
+            let mut list: Vec<_> = self
+                .bundle
+                .pokemon
+                .iter()
+                .filter_map(|p| {
+                    matcher
+                        .fuzzy_match(&p.name_with_no(), &filter)
+                        .map(|score| (score, p.clone()))
+                })
+                .collect();
+
+            list.sort_by_key(|&(score, _)| -score);
+            self.filtered_list = list.into_iter().map(|(_, p)| p).collect();
         };
 
         self.select(0);


### PR DESCRIPTION
- Integrated `fuzzy-matcher` for ranked, fzf-like search results.
- Enabled Up/Down arrow navigation directly within the search bar.
- Fixed list wrap-around logic for filtered search results.
- Added Ctrl+C as a global exit command across all modes.