### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,8 +1,10 @@
+use std::sync::OnceLock;
+
 use lazy_static::lazy_static;
 use sys_locale::get_locale;
 
 pub static LIST_H_MARGIN: u16 = 2;
-pub static mut DEF_LOCALES: &str = "en";
+pub static DEF_LOCALES: OnceLock<&'static str> = OnceLock::new();
 
 lazy_static! {
     pub static ref LOCALES: String = get_locale()

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,9 +74,9 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let assets_dir = get_assets_dir_path()?;
 
-    unsafe {
-        DEF_LOCALES = Box::leak(args.locale.into_boxed_str());
-    }
+    DEF_LOCALES
+        .set(Box::leak(args.locale.into_boxed_str()))
+        .ok();
 
     let Ok((pokemon, ability, ascii)) = load_data() else {
         println!("load data error");

--- a/src/pokemon/translate.rs
+++ b/src/pokemon/translate.rs
@@ -11,25 +11,24 @@ pub struct TranslateText {
 
 impl TranslateText {
     pub fn get(&self) -> String {
-        unsafe {
-            let loc = if !DEF_LOCALES.eq(LOCALES.as_str()) {
-                DEF_LOCALES
-            } else {
-                LOCALES.as_str()
-            };
+        let def_locales = DEF_LOCALES.get().copied().unwrap_or("en");
+        let loc = if def_locales != LOCALES.as_str() {
+            def_locales
+        } else {
+            LOCALES.as_str()
+        };
 
-            let text = match loc {
-                "en" => &self.en,
-                "zh" => &self.zh,
-                "ja" => &self.jp,
-                _ => &self.en,
-            };
+        let text = match loc {
+            "en" => &self.en,
+            "zh" => &self.zh,
+            "ja" => &self.jp,
+            _ => &self.en,
+        };
 
-            if !text.is_empty() {
-                text.to_string()
-            } else {
-                self.en.clone()
-            }
+        if !text.is_empty() {
+            text.to_string()
+        } else {
+            self.en.clone()
         }
     }
 }

--- a/src/widget/filter.rs
+++ b/src/widget/filter.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct Filter;
 
 impl Filter {
-    fn paragraph(self, scroll: usize, value: &str) -> Paragraph {
+    fn paragraph(self, scroll: usize, value: &str) -> Paragraph<'_> {
         Paragraph::new(value)
             .style(Style::default().fg(Color::Yellow))
             .scroll((0, scroll as u16))


### PR DESCRIPTION
- Fix lifetime elision warning in `src/widget/filter.rs`.
- Replace dangerous `static mut` with `OnceLock` in `src/env.rs`.
- Remove `unsafe` block in `src/pokemon/translate.rs` by using `OnceLock`.